### PR TITLE
feat(CameraRig): add haptics and supplement cameras to rig

### DIFF
--- a/Runtime/Prefabs/CameraRigs.OculusIntegration.prefab
+++ b/Runtime/Prefabs/CameraRigs.OculusIntegration.prefab
@@ -1,5 +1,92 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4002046333319816461
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 822158438033722709}
+  - component: {fileID: 3964599098699340031}
+  m_Layer: 0
+  m_Name: SupplementCameras
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &822158438033722709
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4002046333319816461}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 7127022811268798731}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &3964599098699340031
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4002046333319816461}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d804466c8a9a27544b016e3cb497de6a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Found:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: Zinnia.Data.Collection.List.CameraObservableList+UnityEvent, Zinnia.Runtime,
+      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  NotFound:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: Zinnia.Data.Collection.List.CameraObservableList+UnityEvent, Zinnia.Runtime,
+      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  IsEmpty:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+  IsPopulated:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+  Populated:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: Zinnia.Data.Collection.List.CameraObservableList+UnityEvent, Zinnia.Runtime,
+      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  Added:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: Zinnia.Data.Collection.List.CameraObservableList+UnityEvent, Zinnia.Runtime,
+      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  Removed:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: Zinnia.Data.Collection.List.CameraObservableList+UnityEvent, Zinnia.Runtime,
+      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  Emptied:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: Zinnia.Data.Collection.List.CameraObservableList+UnityEvent, Zinnia.Runtime,
+      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  currentIndex: 0
+  elements:
+  - {fileID: 7110982169460027041}
+  - {fileID: 7110982167418695995}
 --- !u!1 &7127022809675772216
 GameObject:
   m_ObjectHideFlags: 0
@@ -322,6 +409,7 @@ Transform:
   - {fileID: 7127022810064477865}
   - {fileID: 7127022809675772217}
   - {fileID: 7127022810581230388}
+  - {fileID: 822158438033722709}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -341,10 +429,13 @@ MonoBehaviour:
   headset: {fileID: 7127022810063979151}
   headsetCamera: {fileID: 7127022810062836085}
   headsetVelocityTracker: {fileID: 7127022810431118832}
+  supplementHeadsetCameras: {fileID: 3964599098699340031}
   leftController: {fileID: 7127022810063990481}
   leftControllerVelocityTracker: {fileID: 7127022810785209772}
+  leftControllerHapticProcess: {fileID: 7127022810852968230}
   rightController: {fileID: 7127022810063992901}
   rightControllerVelocityTracker: {fileID: 7127022810501528420}
+  rightControllerHapticProcess: {fileID: 7127022810533420026}
 --- !u!1001 &7127022810064077869
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -402,9 +493,9 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 126d619cf4daa52469682f85c1378b4a, type: 3}
---- !u!1 &7127022810063979145 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 100004, guid: 126d619cf4daa52469682f85c1378b4a,
+--- !u!20 &7110982169460027041 stripped
+Camera:
+  m_CorrespondingSourceObject: {fileID: 20000012175207052, guid: 126d619cf4daa52469682f85c1378b4a,
     type: 3}
   m_PrefabInstance: {fileID: 7127022810064077869}
   m_PrefabAsset: {fileID: 0}
@@ -414,15 +505,15 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 7127022810064077869}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &7127022810063979151 stripped
+--- !u!1 &7127022810063979145 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 100002, guid: 126d619cf4daa52469682f85c1378b4a,
+  m_CorrespondingSourceObject: {fileID: 100004, guid: 126d619cf4daa52469682f85c1378b4a,
     type: 3}
   m_PrefabInstance: {fileID: 7127022810064077869}
   m_PrefabAsset: {fileID: 0}
---- !u!20 &7127022810062836085 stripped
-Camera:
-  m_CorrespondingSourceObject: {fileID: 2037080, guid: 126d619cf4daa52469682f85c1378b4a,
+--- !u!1 &7127022810063992901 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 113768, guid: 126d619cf4daa52469682f85c1378b4a,
     type: 3}
   m_PrefabInstance: {fileID: 7127022810064077869}
   m_PrefabAsset: {fileID: 0}
@@ -432,9 +523,21 @@ GameObject:
     type: 3}
   m_PrefabInstance: {fileID: 7127022810064077869}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &7127022810063992901 stripped
+--- !u!20 &7110982167418695995 stripped
+Camera:
+  m_CorrespondingSourceObject: {fileID: 20000010189485334, guid: 126d619cf4daa52469682f85c1378b4a,
+    type: 3}
+  m_PrefabInstance: {fileID: 7127022810064077869}
+  m_PrefabAsset: {fileID: 0}
+--- !u!20 &7127022810062836085 stripped
+Camera:
+  m_CorrespondingSourceObject: {fileID: 2037080, guid: 126d619cf4daa52469682f85c1378b4a,
+    type: 3}
+  m_PrefabInstance: {fileID: 7127022810064077869}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &7127022810063979151 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 113768, guid: 126d619cf4daa52469682f85c1378b4a,
+  m_CorrespondingSourceObject: {fileID: 100002, guid: 126d619cf4daa52469682f85c1378b4a,
     type: 3}
   m_PrefabInstance: {fileID: 7127022810064077869}
   m_PrefabAsset: {fileID: 0}


### PR DESCRIPTION
The TrackedAlias now allows for haptic processors for the controller
and a list of any supplement cameras found on the camera rig.

The Oculus haptic processors have been added to the rig along with
the references to the additional left and right cameras.