### PR TITLE
fix(Tracking): account for parent rotations when calculating velocity

### DIFF
--- a/Runtime/Prefabs/CameraRigs.OculusIntegration.prefab
+++ b/Runtime/Prefabs/CameraRigs.OculusIntegration.prefab
@@ -164,6 +164,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   trackedGameObject: {fileID: 7127022810063979151}
+  relativeTo: {fileID: 7127022810063979145}
 --- !u!1 &7127022810501528422
 GameObject:
   m_ObjectHideFlags: 0
@@ -208,6 +209,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   trackedGameObject: {fileID: 7127022810063992901}
+  relativeTo: {fileID: 7127022810063979145}
 --- !u!1 &7127022810533420005
 GameObject:
   m_ObjectHideFlags: 0
@@ -331,6 +333,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   trackedGameObject: {fileID: 7127022810063990481}
+  relativeTo: {fileID: 7127022810063979145}
 --- !u!1 &7127022810852968224
 GameObject:
   m_ObjectHideFlags: 0

--- a/Runtime/SharedResources/Scripts/Tracking/Velocity/OVRAnchorVelocityEstimator.cs
+++ b/Runtime/SharedResources/Scripts/Tracking/Velocity/OVRAnchorVelocityEstimator.cs
@@ -16,6 +16,12 @@
         [Serialized]
         [field: DocumentedByXml]
         public GameObject TrackedGameObject { get; set; }
+        /// <summary>
+        /// An optional <see cref="GameObject"/> to consider the source relative to when retrieving velocities.
+        /// </summary>
+        [Serialized]
+        [field: DocumentedByXml]
+        public GameObject RelativeTo { get; set; }
 
         /// <inheritdoc />
         public override bool IsActive()
@@ -29,11 +35,11 @@
             switch (TrackedGameObject.name)
             {
                 case "CenterEyeAnchor":
-                    return (OVRManager.isHmdPresent ? OVRPlugin.GetNodeVelocity(OVRPlugin.Node.EyeCenter, OVRPlugin.Step.Render).FromFlippedZVector3f() : Vector3.zero);
+                    return RelativeTo.transform.rotation * (OVRManager.isHmdPresent ? OVRPlugin.GetNodeVelocity(OVRPlugin.Node.EyeCenter, OVRPlugin.Step.Render).FromFlippedZVector3f() : Vector3.zero);
                 case "LeftHandAnchor":
-                    return OVRInput.GetLocalControllerVelocity(OVRInput.Controller.LTouch);
+                    return RelativeTo.transform.rotation * OVRInput.GetLocalControllerVelocity(OVRInput.Controller.LTouch);
                 case "RightHandAnchor":
-                    return OVRInput.GetLocalControllerVelocity(OVRInput.Controller.RTouch);
+                    return RelativeTo.transform.rotation * OVRInput.GetLocalControllerVelocity(OVRInput.Controller.RTouch);
                 default:
                     return Vector3.zero;
             }
@@ -45,11 +51,11 @@
             switch (TrackedGameObject.name)
             {
                 case "CenterEyeAnchor":
-                    return (OVRManager.isHmdPresent ? OVRPlugin.GetNodeAngularVelocity(OVRPlugin.Node.EyeCenter, OVRPlugin.Step.Render).FromFlippedZVector3f() : Vector3.zero);
+                    return TrackedGameObject.transform.rotation * (OVRManager.isHmdPresent ? OVRPlugin.GetNodeAngularVelocity(OVRPlugin.Node.EyeCenter, OVRPlugin.Step.Render).FromFlippedZVector3f() : Vector3.zero);
                 case "LeftHandAnchor":
-                    return OVRInput.GetLocalControllerAngularVelocity(OVRInput.Controller.LTouch);
+                    return TrackedGameObject.transform.rotation * OVRInput.GetLocalControllerAngularVelocity(OVRInput.Controller.LTouch);
                 case "RightHandAnchor":
-                    return OVRInput.GetLocalControllerAngularVelocity(OVRInput.Controller.RTouch);
+                    return TrackedGameObject.transform.rotation * OVRInput.GetLocalControllerAngularVelocity(OVRInput.Controller.RTouch);
                 default:
                     return Vector3.zero;
             }


### PR DESCRIPTION
The velocity calculations need to take in consideration the rotation
of the camera rig otherwise they report the incorrect velocity values.