### PR TITLE
fix(Utility): update namespace to be correct

### DIFF
--- a/Editor/Utility/PrefabCreator.cs
+++ b/Editor/Utility/PrefabCreator.cs
@@ -1,4 +1,4 @@
-namespace Tilia.CameraRigs.TrackedAlias.Utility
+namespace Tilia.SDK.OculusIntegration.Utility
 {
     using System.IO;
     using UnityEditor;


### PR DESCRIPTION
The namespace for the PrefabCreator was not correct and was a copy
and paste issue. It has now been updated to the correct namespace.