### PR TITLE
feat(DeviceDetails): add passthrough camera details

### DIFF
--- a/Documentation/API/Input/OVRInput1DAxisAction.md
+++ b/Documentation/API/Input/OVRInput1DAxisAction.md
@@ -34,7 +34,7 @@ IProcessable
 ##### Syntax
 
 ```
-public class OVRInput1DAxisAction : FloatAction, IProcessable, OVRInputControllable
+public class OVRInput1DAxisAction : FloatAction, OVRInputControllable
 ```
 
 ### Properties

--- a/Documentation/API/Input/OVRInput2DAxisAction.md
+++ b/Documentation/API/Input/OVRInput2DAxisAction.md
@@ -34,7 +34,7 @@ IProcessable
 ##### Syntax
 
 ```
-public class OVRInput2DAxisAction : Vector2Action, IProcessable, OVRInputControllable
+public class OVRInput2DAxisAction : Vector2Action, OVRInputControllable
 ```
 
 ### Properties

--- a/Documentation/API/Input/OVRInputButtonAction.md
+++ b/Documentation/API/Input/OVRInputButtonAction.md
@@ -34,7 +34,7 @@ IProcessable
 ##### Syntax
 
 ```
-public class OVRInputButtonAction : BooleanAction, IProcessable, OVRInputControllable
+public class OVRInputButtonAction : BooleanAction, OVRInputControllable
 ```
 
 ### Properties

--- a/Documentation/API/Input/OVRInputNearTouchAction.md
+++ b/Documentation/API/Input/OVRInputNearTouchAction.md
@@ -34,7 +34,7 @@ IProcessable
 ##### Syntax
 
 ```
-public class OVRInputNearTouchAction : BooleanAction, IProcessable, OVRInputControllable
+public class OVRInputNearTouchAction : BooleanAction, OVRInputControllable
 ```
 
 ### Properties

--- a/Documentation/API/Input/OVRInputTouchAction.md
+++ b/Documentation/API/Input/OVRInputTouchAction.md
@@ -34,7 +34,7 @@ IProcessable
 ##### Syntax
 
 ```
-public class OVRInputTouchAction : BooleanAction, IProcessable, OVRInputControllable
+public class OVRInputTouchAction : BooleanAction, OVRInputControllable
 ```
 
 ### Properties

--- a/Documentation/API/Tracking/CameraRig/OVRInputDetailsRecord.md
+++ b/Documentation/API/Tracking/CameraRig/OVRInputDetailsRecord.md
@@ -9,6 +9,7 @@
   * [BatteryChargeStatus]
   * [BatteryLevel]
   * [Controller]
+  * [HasPassThroughCamera]
   * [IsConnected]
   * [Priority]
   * [XRNodeType]
@@ -60,6 +61,14 @@ OVR Controller type.
 
 ```
 public OVRInput.Controller Controller { get; set; }
+```
+
+#### HasPassThroughCamera
+
+##### Declaration
+
+```
+public override bool HasPassThroughCamera { get; protected set; }
 ```
 
 #### IsConnected
@@ -157,6 +166,7 @@ public virtual void SetControllerType(int index)
 [BatteryChargeStatus]: #BatteryChargeStatus
 [BatteryLevel]: #BatteryLevel
 [Controller]: #Controller
+[HasPassThroughCamera]: #HasPassThroughCamera
 [IsConnected]: #IsConnected
 [Priority]: #Priority
 [XRNodeType]: #XRNodeType

--- a/Documentation/API/Tracking/CameraRig/OVRPluginDetailsRecord.md
+++ b/Documentation/API/Tracking/CameraRig/OVRPluginDetailsRecord.md
@@ -8,9 +8,16 @@
 * [Properties]
   * [BatteryChargeStatus]
   * [BatteryLevel]
+  * [HasPassThroughCamera]
   * [Model]
+  * [PassthroughLayer]
+  * [PassthroughLayerHiddenOnEnable]
   * [Priority]
   * [XRNodeType]
+* [Methods]
+  * [DisablePassThrough()]
+  * [EnablePassThrough()]
+  * [OnEnable()]
 
 ## Details
 
@@ -47,12 +54,40 @@ public override BatteryStatus BatteryChargeStatus { get; protected set; }
 public override float BatteryLevel { get; protected set; }
 ```
 
+#### HasPassThroughCamera
+
+##### Declaration
+
+```
+public override bool HasPassThroughCamera { get; protected set; }
+```
+
 #### Model
 
 ##### Declaration
 
 ```
 public override string Model { get; protected set; }
+```
+
+#### PassthroughLayer
+
+The OVRPassthroughLayer component for controlling camera passthrough.
+
+##### Declaration
+
+```
+public OVRPassthroughLayer PassthroughLayer { get; set; }
+```
+
+#### PassthroughLayerHiddenOnEnable
+
+Whether the OVRPassthroughLayer component is hidden on enable. Does not raise events.
+
+##### Declaration
+
+```
+public bool PassthroughLayerHiddenOnEnable { get; set; }
 ```
 
 #### Priority
@@ -71,6 +106,32 @@ public override int Priority { get; protected set; }
 public override XRNode XRNodeType { get; protected set; }
 ```
 
+### Methods
+
+#### DisablePassThrough()
+
+##### Declaration
+
+```
+protected override void DisablePassThrough()
+```
+
+#### EnablePassThrough()
+
+##### Declaration
+
+```
+protected override void EnablePassThrough()
+```
+
+#### OnEnable()
+
+##### Declaration
+
+```
+protected override void OnEnable()
+```
+
 [Tilia.SDK.OculusIntegration.Tracking.CameraRig]: README.md
 [Inheritance]: #Inheritance
 [Namespace]: #Namespace
@@ -78,6 +139,13 @@ public override XRNode XRNodeType { get; protected set; }
 [Properties]: #Properties
 [BatteryChargeStatus]: #BatteryChargeStatus
 [BatteryLevel]: #BatteryLevel
+[HasPassThroughCamera]: #HasPassThroughCamera
 [Model]: #Model
+[PassthroughLayer]: #PassthroughLayer
+[PassthroughLayerHiddenOnEnable]: #PassthroughLayerHiddenOnEnable
 [Priority]: #Priority
 [XRNodeType]: #XRNodeType
+[Methods]: #Methods
+[DisablePassThrough()]: #DisablePassThrough
+[EnablePassThrough()]: #EnablePassThrough
+[OnEnable()]: #OnEnable

--- a/Runtime/SharedResources/Scripts/Tracking/CameraRig/OVRInputDetailsRecord.cs
+++ b/Runtime/SharedResources/Scripts/Tracking/CameraRig/OVRInputDetailsRecord.cs
@@ -35,6 +35,8 @@
         public override float BatteryLevel { get => OVRInput.GetControllerBatteryPercentRemaining(Controller) / 100f; protected set => throw new System.NotImplementedException(); }
         /// <inheritdoc/>
         public override BatteryStatus BatteryChargeStatus { get => BatteryStatus.Unknown; protected set => throw new System.NotImplementedException(); }
+        /// <inheritdoc/>
+        public override bool HasPassThroughCamera { get => false; protected set => throw new System.NotImplementedException(); }
 
         /// <summary>
         /// Sets the <see cref="Controller"/>.

--- a/Runtime/SharedResources/Scripts/Tracking/CameraRig/OVRPluginDetailsRecord.cs
+++ b/Runtime/SharedResources/Scripts/Tracking/CameraRig/OVRPluginDetailsRecord.cs
@@ -6,6 +6,40 @@
 
     public class OVRPluginDetailsRecord : BaseDeviceDetailsRecord
     {
+        [Tooltip("The OVRPassthroughLayer component for controlling camera passthrough.")]
+        [SerializeField]
+        private OVRPassthroughLayer passthroughLayer;
+        /// <summary>
+        /// The <see cref="OVRPassthroughLayer"/> component for controlling camera passthrough.
+        /// </summary>
+        public OVRPassthroughLayer PassthroughLayer
+        {
+            get
+            {
+                return passthroughLayer;
+            }
+            set
+            {
+                passthroughLayer = value;
+            }
+        }
+        [Tooltip("Whether The OVRPassthroughLayer component is hidden on enable. Does not raise events.")]
+        [SerializeField]
+        private bool passthroughLayerHiddenOnEnable;
+        /// <summary>
+        /// Whether the <see cref="OVRPassthroughLayer"/> component is hidden on enable. Does not raise events.
+        /// </summary>
+        public bool PassthroughLayerHiddenOnEnable
+        {
+            get
+            {
+                return passthroughLayerHiddenOnEnable;
+            }
+            set
+            {
+                passthroughLayerHiddenOnEnable = value;
+            }
+        }
         /// <inheritdoc/>
         public override XRNode XRNodeType { get => XRNode.Head; protected set => throw new System.NotImplementedException(); }
         /// <inheritdoc/>
@@ -16,5 +50,27 @@
         public override float BatteryLevel { get => SystemInfo.batteryLevel; protected set => throw new System.NotImplementedException(); }
         /// <inheritdoc/>
         public override BatteryStatus BatteryChargeStatus { get => SystemInfo.batteryStatus; protected set => throw new System.NotImplementedException(); }
+        /// <inheritdoc/>
+        public override bool HasPassThroughCamera { get => passthroughLayer != null; protected set => throw new System.NotImplementedException(); }
+
+        protected override void OnEnable()
+        {
+            passthroughLayer.hidden = PassthroughLayerHiddenOnEnable;
+            base.OnEnable();
+        }
+
+        /// <inheritdoc/>
+        protected override void EnablePassThrough()
+        {
+            passthroughLayer.hidden = false;
+            base.EnablePassThrough();
+        }
+
+        /// <inheritdoc/>
+        protected override void DisablePassThrough()
+        {
+            passthroughLayer.hidden = true;
+            base.DisablePassThrough();
+        }
     }
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "url": "https://github.com/ExtendRealityLtd"
     },
     "dependencies": {
-        "io.extendreality.zinnia.unity": "2.6.0"
+        "io.extendreality.zinnia.unity": "2.7.0"
     },
     "files": [
         "*.md",


### PR DESCRIPTION
The DeviceDetailsRecord now supports passthrough camera options and the Oculus Integration SDK supports a PassThrough layer for the Headset cameras.

This adds the ability to access the passthrough SDK via a generic mechanism on the OVRPluginDetailsRecord, which is used for the DeviceDetailsRecord for the headset.

The OVRInputDetailsRecord, which is used for controllers just implements a default false output as no controllers support passthrough as of yet.