### PR TITLE
fix(Tracking): prevent null reference if no passthrough layer is given

### DIFF
--- a/Runtime/SharedResources/Scripts/Tracking/CameraRig/OVRPluginDetailsRecord.cs
+++ b/Runtime/SharedResources/Scripts/Tracking/CameraRig/OVRPluginDetailsRecord.cs
@@ -55,20 +55,36 @@
 
         protected override void OnEnable()
         {
-            passthroughLayer.hidden = PassthroughLayerHiddenOnEnable;
             base.OnEnable();
+
+            if (PassthroughLayer == null)
+            {
+                return;
+            }
+
+            PassthroughLayer.hidden = PassthroughLayerHiddenOnEnable;
         }
 
         /// <inheritdoc/>
         protected override void EnablePassThrough()
         {
-            passthroughLayer.hidden = false;
+            if (PassthroughLayer == null)
+            {
+                return;
+            }
+
+            PassthroughLayer.hidden = false;
             base.EnablePassThrough();
         }
 
         /// <inheritdoc/>
         protected override void DisablePassThrough()
         {
+            if (PassthroughLayer == null)
+            {
+                return;
+            }
+
             passthroughLayer.hidden = true;
             base.DisablePassThrough();
         }


### PR DESCRIPTION
The OVRPluginDetailsRecord can take an optional OVRPassthroughLayer component but it would give a null reference error if one was not provided. This has been fixed by checking to see if the reference is null before trying to perform actions on it.