### PR TITLE
fix(Tracking): ensure controller angular velocity is correct - fixes #77

### DIFF
--- a/Documentation/API/Tracking/CameraRig/OVRPluginDetailsRecord.PassThroughSetting.md
+++ b/Documentation/API/Tracking/CameraRig/OVRPluginDetailsRecord.PassThroughSetting.md
@@ -1,0 +1,69 @@
+## Contents
+
+* [Inheritance]
+* [Namespace]
+* [Syntax]
+* [Properties]
+  * [PassthroughLayer]
+  * [PassthroughLayerHiddenOnEnable]
+
+## Details
+
+# Struct OVRPluginDetailsRecord.PassThroughSetting
+
+A setting for each Passthrough layer.
+
+##### Inherited Members
+
+System.ValueType.Equals(System.Object)
+
+System.ValueType.GetHashCode()
+
+System.ValueType.ToString()
+
+System.Object.Equals(System.Object, System.Object)
+
+System.Object.ReferenceEquals(System.Object, System.Object)
+
+System.Object.GetType()
+
+##### Namespace
+
+* [Tilia.SDK.OculusIntegration.Tracking.CameraRig]
+
+##### Syntax
+
+```
+[Serializable]
+public struct PassThroughSetting
+```
+
+### Properties
+
+#### PassthroughLayer
+
+The OVRPassthroughLayer component for controlling camera passthrough.
+
+##### Declaration
+
+```
+public OVRPassthroughLayer PassthroughLayer { get; set; }
+```
+
+#### PassthroughLayerHiddenOnEnable
+
+Whether the OVRPassthroughLayer component is hidden on enable. Does not raise events.
+
+##### Declaration
+
+```
+public bool PassthroughLayerHiddenOnEnable { get; set; }
+```
+
+[Tilia.SDK.OculusIntegration.Tracking.CameraRig]: README.md
+[Inheritance]: #Inheritance
+[Namespace]: #Namespace
+[Syntax]: #Syntax
+[Properties]: #Properties
+[PassthroughLayer]: #PassthroughLayer
+[PassthroughLayerHiddenOnEnable]: #PassthroughLayerHiddenOnEnable

--- a/Documentation/API/Tracking/CameraRig/OVRPluginDetailsRecord.PassThroughSetting.md.meta
+++ b/Documentation/API/Tracking/CameraRig/OVRPluginDetailsRecord.PassThroughSetting.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 222d4de2bd5fae44da2ac7bf6fbc60a7
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Documentation/API/Tracking/CameraRig/OVRPluginDetailsRecord.md
+++ b/Documentation/API/Tracking/CameraRig/OVRPluginDetailsRecord.md
@@ -10,14 +10,15 @@
   * [BatteryLevel]
   * [HasPassThroughCamera]
   * [Model]
-  * [PassthroughLayer]
-  * [PassthroughLayerHiddenOnEnable]
+  * [PassthroughLayerOptions]
   * [Priority]
   * [XRNodeType]
 * [Methods]
   * [DisablePassThrough()]
   * [EnablePassThrough()]
+  * [HasPassthroughLayer()]
   * [OnEnable()]
+  * [SetPassthroughLayerState(Nullable<Boolean>)]
 
 ## Details
 
@@ -70,24 +71,14 @@ public override bool HasPassThroughCamera { get; protected set; }
 public override string Model { get; protected set; }
 ```
 
-#### PassthroughLayer
+#### PassthroughLayerOptions
 
-The OVRPassthroughLayer component for controlling camera passthrough.
-
-##### Declaration
-
-```
-public OVRPassthroughLayer PassthroughLayer { get; set; }
-```
-
-#### PassthroughLayerHiddenOnEnable
-
-Whether the OVRPassthroughLayer component is hidden on enable. Does not raise events.
+The collection of OVRPassthroughLayer components for controlling camera passthrough.
 
 ##### Declaration
 
 ```
-public bool PassthroughLayerHiddenOnEnable { get; set; }
+public List<OVRPluginDetailsRecord.PassThroughSetting> PassthroughLayerOptions { get; set; }
 ```
 
 #### Priority
@@ -124,6 +115,22 @@ protected override void DisablePassThrough()
 protected override void EnablePassThrough()
 ```
 
+#### HasPassthroughLayer()
+
+Determines whether there are any set passthrough layers.
+
+##### Declaration
+
+```
+protected virtual bool HasPassthroughLayer()
+```
+
+##### Returns
+
+| Type | Description |
+| --- | --- |
+| System.Boolean | Whether a passthrough layer exists. |
+
 #### OnEnable()
 
 ##### Declaration
@@ -132,7 +139,30 @@ protected override void EnablePassThrough()
 protected override void OnEnable()
 ```
 
+#### SetPassthroughLayerState(Nullable<Boolean>)
+
+Sets the passthrough layer state.
+
+##### Declaration
+
+```
+protected virtual bool SetPassthroughLayerState(bool? state)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Nullable<System.Boolean\> | state | The state to set. If null is passed then it uses the setting's Tilia.SDK.OculusIntegration.Tracking.CameraRig.OVRPluginDetailsRecord.PassThroughSetting.passthroughLayerHiddenOnEnable value. |
+
+##### Returns
+
+| Type | Description |
+| --- | --- |
+| System.Boolean | Whether any passthrough layer state was set. |
+
 [Tilia.SDK.OculusIntegration.Tracking.CameraRig]: README.md
+[OVRPluginDetailsRecord.PassThroughSetting]: OVRPluginDetailsRecord.PassThroughSetting.md
 [Inheritance]: #Inheritance
 [Namespace]: #Namespace
 [Syntax]: #Syntax
@@ -141,11 +171,12 @@ protected override void OnEnable()
 [BatteryLevel]: #BatteryLevel
 [HasPassThroughCamera]: #HasPassThroughCamera
 [Model]: #Model
-[PassthroughLayer]: #PassthroughLayer
-[PassthroughLayerHiddenOnEnable]: #PassthroughLayerHiddenOnEnable
+[PassthroughLayerOptions]: #PassthroughLayerOptions
 [Priority]: #Priority
 [XRNodeType]: #XRNodeType
 [Methods]: #Methods
 [DisablePassThrough()]: #DisablePassThrough
 [EnablePassThrough()]: #EnablePassThrough
+[HasPassthroughLayer()]: #HasPassthroughLayer
 [OnEnable()]: #OnEnable
+[SetPassthroughLayerState(Nullable<Boolean>)]: #SetPassthroughLayerStateNullable<Boolean>

--- a/Documentation/API/Tracking/CameraRig/README.md
+++ b/Documentation/API/Tracking/CameraRig/README.md
@@ -6,5 +6,12 @@
 
 #### [OVRPluginDetailsRecord]
 
+### Structs
+
+#### [OVRPluginDetailsRecord.PassThroughSetting]
+
+A setting for each Passthrough layer.
+
 [OVRInputDetailsRecord]: OVRInputDetailsRecord.md
 [OVRPluginDetailsRecord]: OVRPluginDetailsRecord.md
+[OVRPluginDetailsRecord.PassThroughSetting]: OVRPluginDetailsRecord.PassThroughSetting.md

--- a/Documentation/API/Tracking/Velocity/OVRAnchorVelocityEstimator.AngularRotation.md
+++ b/Documentation/API/Tracking/Velocity/OVRAnchorVelocityEstimator.AngularRotation.md
@@ -1,0 +1,37 @@
+## Contents
+
+* [Inheritance]
+* [Namespace]
+* [Syntax]
+* [Fields]
+
+## Details
+
+# Enum OVRAnchorVelocityEstimator.AngularRotation
+
+The source of the Angular Velocity rotation multiplier
+
+##### Namespace
+
+* [Tilia.SDK.OculusIntegration.Tracking.Velocity]
+
+##### Syntax
+
+```
+public enum AngularRotation
+```
+
+### Fields
+
+| Name | Description |
+| --- | --- |
+| RelativeTo | Uses [RelativeTo] as the rotation multiplier. |
+| TrackedGameObject | Uses [TrackedGameObject] as the rotation multiplier. |
+
+[Tilia.SDK.OculusIntegration.Tracking.Velocity]: README.md
+[RelativeTo]: OVRAnchorVelocityEstimator.AngularRotation.md#RelativeTo
+[TrackedGameObject]: OVRAnchorVelocityEstimator.AngularRotation.md#TrackedGameObject
+[Inheritance]: #Inheritance
+[Namespace]: #Namespace
+[Syntax]: #Syntax
+[Fields]: #Fields

--- a/Documentation/API/Tracking/Velocity/OVRAnchorVelocityEstimator.AngularRotation.md.meta
+++ b/Documentation/API/Tracking/Velocity/OVRAnchorVelocityEstimator.AngularRotation.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 7e77eb1c89e10314093633b9e7f7b61a
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Documentation/API/Tracking/Velocity/OVRAnchorVelocityEstimator.md
+++ b/Documentation/API/Tracking/Velocity/OVRAnchorVelocityEstimator.md
@@ -8,12 +8,15 @@ Retrieves the velocity and angular velocity from the specific named OVRCameraRig
 * [Namespace]
 * [Syntax]
 * [Properties]
+  * [AngularRotationSource]
+  * [RelativeRotation]
   * [RelativeTo]
   * [TrackedGameObject]
 * [Methods]
   * [DoGetAngularVelocity()]
   * [DoGetVelocity()]
   * [IsActive()]
+  * [SetAngularRotationSource(Int32)]
 
 ## Details
 
@@ -33,6 +36,26 @@ public class OVRAnchorVelocityEstimator : VelocityTracker
 ```
 
 ### Properties
+
+#### AngularRotationSource
+
+The source of the Angular Velocity rotation multiplier.
+
+##### Declaration
+
+```
+public OVRAnchorVelocityEstimator.AngularRotation AngularRotationSource { get; set; }
+```
+
+#### RelativeRotation
+
+The rotation of [RelativeTo] if it is set, otherwise Quaternion.identity.
+
+##### Declaration
+
+```
+protected virtual Quaternion RelativeRotation { get; }
+```
 
 #### RelativeTo
 
@@ -98,14 +121,36 @@ public override bool IsActive()
 | --- | --- |
 | System.Boolean | n/a |
 
+#### SetAngularRotationSource(Int32)
+
+Sets the [AngularRotationSource].
+
+##### Declaration
+
+```
+public virtual void SetAngularRotationSource(int index)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Int32 | index | The index of the [OVRAnchorVelocityEstimator.AngularRotation]. |
+
 [Tilia.SDK.OculusIntegration.Tracking.Velocity]: README.md
+[RelativeTo]: OVRAnchorVelocityEstimator.md#RelativeTo
+[AngularRotationSource]: OVRAnchorVelocityEstimator.md#AngularRotationSource
+[OVRAnchorVelocityEstimator.AngularRotation]: OVRAnchorVelocityEstimator.AngularRotation.md
 [Inheritance]: #Inheritance
 [Namespace]: #Namespace
 [Syntax]: #Syntax
 [Properties]: #Properties
+[AngularRotationSource]: #AngularRotationSource
+[RelativeRotation]: #RelativeRotation
 [RelativeTo]: #RelativeTo
 [TrackedGameObject]: #TrackedGameObject
 [Methods]: #Methods
 [DoGetAngularVelocity()]: #DoGetAngularVelocity
 [DoGetVelocity()]: #DoGetVelocity
 [IsActive()]: #IsActive
+[SetAngularRotationSource(Int32)]: #SetAngularRotationSourceInt32

--- a/Documentation/API/Tracking/Velocity/README.md
+++ b/Documentation/API/Tracking/Velocity/README.md
@@ -6,4 +6,11 @@
 
 Retrieves the velocity and angular velocity from the specific named OVRCameraRig tracked anchor (CenterEyeAnchor, LeftHandAnchor, RightHandAnchor).
 
+### Enums
+
+#### [OVRAnchorVelocityEstimator.AngularRotation]
+
+The source of the Angular Velocity rotation multiplier
+
 [OVRAnchorVelocityEstimator]: OVRAnchorVelocityEstimator.md
+[OVRAnchorVelocityEstimator.AngularRotation]: OVRAnchorVelocityEstimator.AngularRotation.md


### PR DESCRIPTION
The controller angular velocity was flipped when deploying to quest. This has now been fixed by flipping the reported angular velocity.

The way in which the relative to body is calculated is also different based on a Quest or Rift headset (for some random reason?!) so there is a new enum that allows the selection of whether to use the TrackedGameObject or the RelativeTo property for the offset multiplier and this will then need to be set based on whether it is a rift or quest headset. This can be done by rules and pattern matching so there won't be any automatic way in case this doesn't catch all scenarios that may come with future headsets.